### PR TITLE
Fix HTML entity encoding

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Take-C&M - デスクトップ風サイト</title>
+    <title>Take-C&amp;M - デスクトップ風サイト</title>
     <script src="https://unpkg.com/winbox@0.2.82/dist/winbox.bundle.min.js"></script>
     <style>
         body {
@@ -210,7 +210,7 @@
     </div>
     <div id="terminal" class="terminal"></div>
     <footer>
-        © 2025 Take-C&M. All rights reserved.
+        © 2025 Take-C&amp;M. All rights reserved.
     </footer>
 
     <script>


### PR DESCRIPTION
## Summary
- escape the `&` character in the company name

## Testing
- `node -e "const fs = require('fs'); const s = fs.readFileSync('index.html','utf8'); console.log(/Take-C&[^a]/.test(s));"`

------
https://chatgpt.com/codex/tasks/task_e_684abefe0b6083229fe4d17dd922b497