### PR TITLE
Fix business page navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,7 @@
         <div>Take-C&M</div>
         <nav>
             <a href="#about">会社概要</a>
+            <a href="business.html">事業一覧</a>
             <a href="#services">サービス紹介</a>
             <a href="#contact">お問い合わせ</a>
         </nav>
@@ -64,6 +65,7 @@
                 <li><strong>クーポンとして利用できるNFT：</strong>取引履歴を記録し、還元ポイントをクーポン代わりに使用できるNFTを発行。</li>
                 <li><strong>コンサルティング・開発支援業務：</strong>サービス設計、企画からチームビルディングやマネジメントまで幅広い領域で企業を支援。顧客のニーズに合わせた技術的課題の解決やアーキテクチャ設計を提供し、効率的かつ効果的なプロジェクト推進を実現。</li>
             </ul>
+            <p><a href="business.html">事業一覧を見る</a></p>
         </section>
         <section id="contact">
             <h2>お問い合わせ</h2>


### PR DESCRIPTION
## Summary
- add navigation link from the landing page to `business.html`
- add "事業一覧を見る" link at the end of the service section

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684bb630d394832291cd9606ecc6318b